### PR TITLE
Add AutoMapper support for folder whitelist operations

### DIFF
--- a/src/Gml.Web.Api.Dto/Files/FolderWhiteListDto.cs
+++ b/src/Gml.Web.Api.Dto/Files/FolderWhiteListDto.cs
@@ -2,7 +2,7 @@
 
 namespace Gml.Web.Api.Dto.Files;
 
-public class FolderWhiteListDto : IFolderInfo
+public class FolderWhiteListDto
 {
     public string ProfileName { get; set; }
     public string Path { get; set; }

--- a/src/Gml.Web.Api/Core/Handlers/FileHandler.cs
+++ b/src/Gml.Web.Api/Core/Handlers/FileHandler.cs
@@ -1,8 +1,11 @@
 using System.Net;
+using AutoMapper;
 using FluentValidation;
+using Gml.Models.System;
 using Gml.Web.Api.Dto.Files;
 using Gml.Web.Api.Dto.Messages;
 using GmlCore.Interfaces;
+using GmlCore.Interfaces.System;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -108,6 +111,7 @@ public class FileHandler : IFileHandler
 
     public static async Task<IResult> AddFolderWhiteList(
         IGmlManager manager,
+        IMapper mapper,
         IValidator<List<FolderWhiteListDto>> validator,
         [FromBody] List<FolderWhiteListDto> folderDto)
     {
@@ -119,6 +123,8 @@ public class FileHandler : IFileHandler
 
         folderDto = folderDto.DistinctBy(x => x.Path).ToList();
 
+        var mappedFolders = mapper.Map<List<LocalFolderInfo>>(folderDto);
+
         var profileNames = folderDto.GroupBy(c => c.ProfileName);
 
         foreach (var profileFolders in profileNames)
@@ -129,7 +135,7 @@ public class FileHandler : IFileHandler
                 return Results.NotFound(ResponseMessage.Create($"Профиль с именем \"{profileFolders.Key}\" не найден",
                     HttpStatusCode.NotFound));
 
-            await manager.Profiles.AddFolderToWhiteList(profile, profileFolders.DistinctBy(c => c.Path));
+            await manager.Profiles.AddFolderToWhiteList(profile, mappedFolders);
         }
 
         return Results.Ok(ResponseMessage.Create($"\"{folderDto.Count}\" папок было успешно добавлено в White-Лист",
@@ -138,6 +144,7 @@ public class FileHandler : IFileHandler
 
     public static async Task<IResult> RemoveFolderWhiteList(
         IGmlManager manager,
+        IMapper mapper,
         IValidator<List<FolderWhiteListDto>> validator,
         [FromBody] List<FolderWhiteListDto> folderDto)
     {
@@ -149,6 +156,8 @@ public class FileHandler : IFileHandler
 
         folderDto = folderDto.DistinctBy(x => x.Path).ToList();
 
+        var mappedFolders = mapper.Map<List<LocalFolderInfo>>(folderDto);
+
         var profileNames = folderDto.GroupBy(c => c.ProfileName);
 
         foreach (var profileFolders in profileNames)
@@ -159,7 +168,7 @@ public class FileHandler : IFileHandler
                 return Results.NotFound(ResponseMessage.Create($"Профиль с именем \"{profileFolders.Key}\" не найден",
                     HttpStatusCode.NotFound));
 
-            await manager.Profiles.RemoveFolderFromWhiteList(profile, profileFolders.DistinctBy(c => c.Path));
+            await manager.Profiles.RemoveFolderFromWhiteList(profile, mappedFolders);
         }
 
         return Results.Ok(ResponseMessage.Create($"\"{folderDto.Count}\" папок было успешно удалено из White-Лист",

--- a/src/Gml.Web.Api/Core/Handlers/IFileHandler.cs
+++ b/src/Gml.Web.Api/Core/Handlers/IFileHandler.cs
@@ -1,4 +1,7 @@
 using System.Collections.Frozen;
+using System.Collections.Frozen;
+using System.Collections.Frozen;
+using AutoMapper;
 using FluentValidation;
 using Gml.Web.Api.Dto.Files;
 using GmlCore.Interfaces;
@@ -24,11 +27,13 @@ public interface IFileHandler
 
     static abstract Task<IResult> AddFolderWhiteList(
         IGmlManager manager,
+        IMapper mapper,
         IValidator<List<FolderWhiteListDto>> validator,
         List<FolderWhiteListDto> folderDto);
 
     static abstract Task<IResult> RemoveFolderWhiteList(
         IGmlManager manager,
+        IMapper mapper,
         IValidator<List<FolderWhiteListDto>> validator,
         List<FolderWhiteListDto> folderDto);
 }

--- a/src/Gml.Web.Api/Core/MappingProfiles/SystemIOMapper.cs
+++ b/src/Gml.Web.Api/Core/MappingProfiles/SystemIOMapper.cs
@@ -10,5 +10,6 @@ public class SystemIOMapper : Profile
     {
         CreateMap<LocalFileInfo, ProfileFileReadDto>();
         CreateMap<FolderWhiteListDto, FolderReadDto>();
+        CreateMap<FolderWhiteListDto, LocalFolderInfo>();
     }
 }


### PR DESCRIPTION
Introduced AutoMapper to the AddFolderWhiteList and RemoveFolderWhiteList methods for folder DTO mapping. Also amended the IFileHandler interface and updated mapping profiles accordingly.