### PR TITLE
Rename FolderReadDto to ProfileFolderReadDto

### DIFF
--- a/src/Gml.Web.Api.Dto/Files/ProfileFolderReadDto.cs
+++ b/src/Gml.Web.Api.Dto/Files/ProfileFolderReadDto.cs
@@ -1,6 +1,6 @@
 ﻿namespace Gml.Web.Api.Dto.Files;
 
-public class FolderReadDto
+public class ProfileFolderReadDto
 {
     public string Path { get; set; }
 }

--- a/src/Gml.Web.Api.Dto/Profile/ProfileReadInfoDto.cs
+++ b/src/Gml.Web.Api.Dto/Profile/ProfileReadInfoDto.cs
@@ -20,7 +20,7 @@ public class ProfileReadInfoDto
     public bool HasUpdate { get; set; }
     public ProfileState State { get; set; }
     public List<ProfileFileReadDto> Files { get; set; }
-    public List<IFolderInfo> WhiteListFolders { get; set; }
+    public List<ProfileFolderReadDto> WhiteListFolders { get; set; }
     public List<ProfileFileReadDto> WhiteListFiles { get; set; }
     public string Background { get; set; }
 }

--- a/src/Gml.Web.Api/Core/MappingProfiles/SystemIOMapper.cs
+++ b/src/Gml.Web.Api/Core/MappingProfiles/SystemIOMapper.cs
@@ -9,7 +9,7 @@ public class SystemIOMapper : Profile
     public SystemIOMapper()
     {
         CreateMap<LocalFileInfo, ProfileFileReadDto>();
-        CreateMap<FolderWhiteListDto, FolderReadDto>();
+        CreateMap<FolderWhiteListDto, ProfileFolderReadDto>();
         CreateMap<FolderWhiteListDto, LocalFolderInfo>();
     }
 }

--- a/src/Gml.Web.Api/Core/MappingProfiles/SystemIOMapper.cs
+++ b/src/Gml.Web.Api/Core/MappingProfiles/SystemIOMapper.cs
@@ -9,7 +9,7 @@ public class SystemIOMapper : Profile
     public SystemIOMapper()
     {
         CreateMap<LocalFileInfo, ProfileFileReadDto>();
-        CreateMap<FolderWhiteListDto, ProfileFolderReadDto>();
+        CreateMap<LocalFolderInfo, ProfileFolderReadDto>();
         CreateMap<FolderWhiteListDto, LocalFolderInfo>();
     }
 }


### PR DESCRIPTION
This change updates the class and related references to better reflect their purpose within the profile context. The modification ensures consistency in class naming conventions, making the codebase more maintainable and easier to understand.