### PR TITLE
Refactor Tests to Use Shared HttpClient

### DIFF
--- a/src/Gml.Web.Api/Gml.Web.Api.csproj
+++ b/src/Gml.Web.Api/Gml.Web.Api.csproj
@@ -51,6 +51,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Gml.WebApi.Tests"/>
+    <InternalsVisibleTo Include="Gml.Backend.Tests"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Gml.WebApi.Tests/Tests.cs
+++ b/tests/Gml.WebApi.Tests/Tests.cs
@@ -50,9 +50,7 @@ public class Tests
     [Order(1)]
     public async Task RemoveAllProfilesEndFiles()
     {
-        var httpClient = _webApplicationFactory.CreateClient();
-
-        var response = await httpClient.GetAsync("/api/v1/profiles");
+        var response = await _httpClient.GetAsync("/api/v1/profiles");
 
         var content = await response.Content.ReadAsStringAsync();
 
@@ -60,7 +58,7 @@ public class Tests
 
         foreach (var profile in model?.Data ?? Enumerable.Empty<ProfileReadDto>())
         {
-            var deleteResponse = await httpClient.DeleteAsync($"/api/v1/profiles/{profile.Name}?removeFiles=true");
+            var deleteResponse = await _httpClient.DeleteAsync($"/api/v1/profiles/{profile.Name}?removeFiles=true");
 
             Assert.That(deleteResponse.IsSuccessStatusCode, Is.True);
         }


### PR DESCRIPTION
Updated the tests to use the shared _httpClient instead of creating a new HttpClient instance. Also added Gml.Backend.Tests to InternalsVisibleTo in the Gml.Web.Api.csproj file for better integration and testing.