### PR TITLE
Protected skin url from null

### DIFF
--- a/src/Gml.Web.Api.Dto/Minecraft/AuthLib/Textures.cs
+++ b/src/Gml.Web.Api.Dto/Minecraft/AuthLib/Textures.cs
@@ -4,7 +4,7 @@ namespace Gml.Web.Api.Dto.Minecraft.AuthLib;
 
 public class Textures
 {
-    [JsonProperty("SKIN")] public SkinCape Skin { get; set; }
+    [JsonProperty("SKIN", NullValueHandling = NullValueHandling.Ignore)] public SkinCape Skin { get; set; }
 
     [JsonProperty("CAPE", NullValueHandling = NullValueHandling.Ignore)] public SkinCape Cape { get; set; }
 }


### PR DESCRIPTION
If skin not setted at join client crashed.
```
java.util.concurrent.CompletionException: java.lang.NullPointerException: Cannot invoke "com.mojang.authlib.minecraft.MinecraftProfileTexture.getUrl()" because the return value of "java.util.Map$Entry.getValue()" is null
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1770) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1760) ~[?:?]
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387) ~[?:?]
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312) ~[?:?]
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843) ~[?:?]
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808) ~[?:?]
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188) ~[?:?]
Caused by: java.lang.NullPointerException: Cannot invoke "com.mojang.authlib.minecraft.MinecraftProfileTexture.getUrl()" because the return value of "java.util.Map$Entry.getValue()" is null
	at com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService.unpackTextures(YggdrasilMinecraftSessionService.java:149) ~[authlib-6.0.54.jar:?]
	at net.minecraft.class_1071$1.method_54647(class_1071.java:55) ~[client-intermediary.jar:?]
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
	... 6 more
```
Skin url cannot be null. If the skin is not setted, the field in json should be missing