### PR TITLE
Make profile properties nullable and handle null scenarios

### DIFF
--- a/src/Gml.Web.Api/Core/Handlers/ProfileHandler.cs
+++ b/src/Gml.Web.Api/Core/Handlers/ProfileHandler.cs
@@ -396,7 +396,9 @@ public class ProfileHandler : IProfileHandler
 
         var profileDto = mapper.Map<ProfileReadInfoDto>(profileInfo);
 
-        profileDto.Background = $"{context.Request.Scheme}://{context.Request.Host}/api/v1/file/{profile.BackgroundImageKey}";
+        profileDto.Background = profile.BackgroundImageKey is not null
+            ? $"{context.Request.Scheme}://{context.Request.Host}/api/v1/file/{profile.BackgroundImageKey}"
+            : profile.BackgroundImageKey;
         profileDto.IsEnabled = profile.IsEnabled;
         profileDto.Priority = profile.Priority;
         profileDto.UsersWhiteList = mapper.Map<List<PlayerReadDto>>(whiteListPlayers);


### PR DESCRIPTION
Updated `IconBase64` and `BackgroundImageKey` to be nullable in `IGameProfile` to better reflect optional fields. Adjusted related logic to handle null values, ensuring safer null checks and default handling across profile operations.